### PR TITLE
Potential fix for code scanning alert no. 17: Client-side cross-site scripting

### DIFF
--- a/web/public/js/portal.js
+++ b/web/public/js/portal.js
@@ -23,7 +23,8 @@ const permsTabMap = {
 
 $(() => {
     let params = new URLSearchParams(window.location.search)
-    let tabName = params.get('tab') || 'UserTab'
+    const validTabs = ['UserTab', 'ItemTab', 'PersonTab', 'PlaceTab', 'TagsTab', 'StaticTab', 'FactTab', 'AdminTab'];
+    let tabName = validTabs.includes(params.get('tab')) ? params.get('tab') : 'UserTab';
     openTab({ currentTarget: `#tab-${tabName}` }, tabName)
     standardGET('portalData')
         .then(({ user, fact, places, items, people, tags, isOverriden, overrideMsg }) => {


### PR DESCRIPTION
Potential fix for [https://github.com/AdamSeidman/DSF-Discord-Bot/security/code-scanning/17](https://github.com/AdamSeidman/DSF-Discord-Bot/security/code-scanning/17)

To fix the issue, we need to sanitize or validate the `tabName` parameter before using it to construct `evt.currentTarget`. This can be achieved by ensuring that `tabName` matches a predefined list of allowed tab names. This approach prevents malicious input from being used in DOM manipulation.

**Steps to fix:**
1. Define a whitelist of valid tab names.
2. Validate `tabName` against the whitelist before using it.
3. If `tabName` is invalid, default to a safe value (e.g., `'UserTab'`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
